### PR TITLE
Add highlight group for supermaven

### DIFF
--- a/after/plugin/lspkind.lua
+++ b/after/plugin/lspkind.lua
@@ -4,6 +4,11 @@ if not status then
 end
 
 lspkind.init({
+  symbol_map = {
+    Supermaven = "",
+  },
   mode = "symbol",
   preset = "codicons",
 })
+
+vim.api.nvim_set_hl(0, "CmpItemKindSupermaven", {fg ="#6CC644"})


### PR DESCRIPTION
### TL;DR

Add configuration for a new symbol and its color highlight called 'Supermaven' in lspkind setup.

### What changed?

- Added 'Supermaven' symbol and its corresponding icon `` in the symbol map.
- Configured the color highlight for 'CmpItemKindSupermaven' with foreground color `#6CC644` in `lspkind.lua`.

### How to test?

1. Ensure `lspkind` is installed and required correctly.
2. Add the updated `lspkind.lua` configuration to your setup.
3. Restart Neovim to apply changes.
4. Verify if the `Supermaven` symbol is displayed with the specified icon and color in the Completion Menu.

### Why make this change?

This change adds a custom symbol 'Supermaven' with a distinct icon and color to enhance the code completion experience in Neovim's `lspkind` setup.

---

